### PR TITLE
fix: update action-suggester version from v1 to v1.22.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_PRETTIER_FLAGS: ${{ inputs.prettier_flags }}
     - if: ${{ inputs.reporter == 'github-pr-review' && always() }}
-      uses: reviewdog/action-suggester@v1
+      uses: reviewdog/action-suggester@v1.22.0
       with:
         github_token: ${{ inputs.github_token }}
         tool_name: ${{ inputs.tool_name }}


### PR DESCRIPTION
## Summary
- Updated `reviewdog/action-suggester` from deprecated v1 to v1.22.0
- Fixes installation errors caused by the deprecated v1 tag

## Problem
The current use of `action-suggester@v1` is causing installation errors during action execution. The v1 tag appears to be deprecated or incompatible with current GitHub Actions runtime.

## Solution
Updated to use the specific version `v1.22.0` which resolves the compatibility issues and ensures stable action execution.

## Test plan
- [ ] Verify the action runs without installation errors
- [ ] Test with `github-pr-review` reporter to ensure suggester functionality works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the automated review suggestion tool used in pull requests to the latest stable release, improving reliability, performance, and consistency of review comments. This update applies to the workflow that posts review feedback on pull requests. No impact on application behavior or user experience; existing inputs and workflow behavior remain the same aside from the underlying tool version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->